### PR TITLE
Fix GitControl case

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -19,7 +19,7 @@ define(function (require, exports) {
         PanelManager       = brackets.getModule("view/PanelManager"),
         ProjectManager     = brackets.getModule("project/ProjectManager"),
         Main               = require("./Main"),
-        GitControl         = require("./gitControl"),
+        GitControl         = require("./GitControl"),
         Strings            = require("../strings"),
         Utils              = require("./Utils");
 


### PR DESCRIPTION
requiring './gitControl' breaks the extension on case-sensitive file systems (e.g. ext3/4 on Linux)
