### PR TITLE
Fixed behavior with check-all checkbox.

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -851,7 +851,7 @@ define(function (require, exports) {
             .on("click", ".check-all", function () {
                 var isChecked = $(this).is(":checked");
                 gitPanel.$panel.find(".check-one").prop("checked", isChecked);
-                toggleCommitButton(isChecked);
+                toggleCommitButton();
             })
             .on("click", ".git-reset", handleGitReset)
             .on("click", ".git-commit", handleGitCommit)


### PR DESCRIPTION
After your refactor there was a bug with the **check-all** checkbox. If there was not files in the git-edited files list, the button was enabled on click on **check-all**.
