### PR TITLE
Adds xfce4-terminal as an option

### DIFF
--- a/shell/terminal.sh
+++ b/shell/terminal.sh
@@ -7,6 +7,10 @@ elif command -v konsole >/dev/null 2>&1
 then
     konsole --workdir "$1"
     echo ok
+elif command -v xfce4-terminal >/dev/null 2>&1
+then
+    xfce4-terminal --window --working-directory="$1"
+    echo ok
 elif command -v xterm >/dev/null 2>&1
 then
     xterm -e 'cd $1 && bash'


### PR DESCRIPTION
Because I like to use it, and XFCE is included in one of the main Ubuntu distributions, Xubuntu.

I foresee future requests for addition of the following terminals:
- aterm
- guake
- lxterminal
- rxvt
- terminator
- tilda
- urxvt
- yakuake

If you'd like I could add those, but I'm not familiar with them. 
