### PR TITLE
Escape special character on username.

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -569,7 +569,7 @@ define(function (require, exports) {
                     if (!hasUsername) {
                         p = p.then(function () {
                             return askQuestion(Strings.TOOLTIP_PUSH, Strings.ENTER_USERNAME).then(function (str) {
-                                username = str;
+                                username = encodeURIComponent(str);
                             });
                         });
                     }


### PR DESCRIPTION
When I try to push to the remote repo, it throws the following error:

```
fatal: unable to access 'https://yfwz100:***@yeah.net@github.com/neuola/neuola-legacy.git/': Couldn't resolve host 'yeah.net@github.com'
```

I don't know if it's better to escape the special characters in the username using encodeURIComponent() method.
