### PR TITLE
Keep scrollPos for every file in commit diff dialog

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1014,7 +1014,6 @@ define(function (require, exports) {
                 $dialog.find(".commit-files a").removeClass("active");
                 self.addClass("active");
                 $dialog.find(".commit-diff").html(Utils.formatDiff(diff));
-                $(this).scrollTop($(this).scrollPos || 0);
                 $(".commit-diff").scrollTop(self.attr("scrollPos") || 0);
             });
         });


### PR DESCRIPTION
Steps to repro the issue:
1. Open the commit diff dialog (from history) of a commit with multiple bigger changes (I took 5b4e64cb8b36759e8863d78f68975698106689f4)
2. Scroll down in one file
3. Switch to another file -> The scrollbar is on the same position
4. Scroll up in that file -> The scrollbar changes for every other file
