### PR TITLE
moved top level menu to better place

### DIFF
--- a/main.js
+++ b/main.js
@@ -68,7 +68,7 @@ define(function (require, exports, module) {
     // Register command and add it to the menu.
 	CommandManager.register(Strings.GIT_SETTINGS, SETTINGS_COMMAND_ID, openSettingsPanel);
 	Menus
-        .addMenu("Git", TOP_MENU_ID)
+        .addMenu("Git", TOP_MENU_ID, Menus.AFTER, Menus.AppMenuBar.NAVIGATE_MENU )
         .addMenuItem(SETTINGS_COMMAND_ID);
 
     AppInit.appReady(function () {


### PR DESCRIPTION
having the git menu to the right of the "help" menu is not right.  I
moved it to just after the "navigate" menu.  When/if Brackets get
submenus, I would hope that this extension removes the top level "git"
menu altogether
