### PR TITLE
Various improvements

### DIFF
--- a/src/HistoryViewer.js
+++ b/src/HistoryViewer.js
@@ -48,6 +48,13 @@ define(function (require, exports) {
             .on("click", ".close", function () {
                 // Close history viewer
                 remove();
+            })
+            .on("click", ".git-extend-sha", function () {
+                // Show complete commit SHA
+                var $parent = $(this).parent(),
+                    sha = $parent.data("hash");
+                $parent.find("span.selectable-text").text(sha);
+                $(this).remove();
             });
 
         // Add/Remove shadown on bottom of header

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -193,7 +193,9 @@ define(function (require, exports) {
             var findStr = "[name='commit-message']",
                 currentValue = $dialog.find(findStr + ":visible").val();
             $dialog.find(findStr).toggle();
-            $dialog.find(findStr + ":visible").val(currentValue);
+            $dialog.find(findStr + ":visible")
+                .val(currentValue)
+                .focus();
             recalculateMessageLength();
         }
 

--- a/src/dialogs/templates/progress-dialog.html
+++ b/src/dialogs/templates/progress-dialog.html
@@ -4,7 +4,7 @@
     </div>
     <div class="modal-body">
         <div class="row-fluid">
-            <textarea class="span12"></textarea>
+            <textarea class="span12" readonly="readonly"></textarea>
         </div>
     </div>
     <!--

--- a/styles/dialogs/progress.less
+++ b/styles/dialogs/progress.less
@@ -1,5 +1,8 @@
 #git-progress-dialog {
     textarea {
         height: 300px;
+        &[readonly="readonly"] {
+            cursor: default;
+        }
     }
 }

--- a/templates/history-viewer.html
+++ b/templates/history-viewer.html
@@ -19,7 +19,7 @@
                 {{/enableAdvancedFeatures}}
                 <a href="#" class="close">×</a>
             </div>
-            <h1 class="commit-title">{{commit.subject}}</h1>
+            <h1 class="commit-title selectable-text">{{commit.subject}}</h1>
         </div>
         <span class="commit-author">
             <div class="commit-author-avatar">
@@ -31,7 +31,8 @@
             <span class="commit-author-name">{{commit.author}}</span>
         </span>
         <span class="commit-hash" data-hash="{{commit.hash}}">
-            <i class="octicon octicon-git-commit"></i>{{commit.hashShort}}
+            <i class="octicon octicon-git-commit"></i><span class="selectable-text">{{commit.hashShort}}</span>
+            <a href="#" class="git-extend-sha">…</a>
         </span>
         <div class="commitBody">{{{bodyMarkdown}}}</div>
     </div>


### PR DESCRIPTION
Changes:
- You can extend the commit SHA and select/copy it (fixes #374/1)
- You can't change the content of a ProgressDialog (fixes #374/3)
- The corresponding input/textarea is automatically focussed after clicking `EXTEND` on the commit dialog
