### PR TITLE
Fixed panel template and the way it loads.

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -936,18 +936,12 @@ define(function (require, exports) {
         // Add panel
         var panelHtml = Mustache.render(gitPanelTemplate, {
             enableAdvancedFeatures: Preferences.get("enableAdvancedFeatures"),
+            showBashButton: Preferences.get("showBashButton"),
+            showReportBugButton: Preferences.get("showReportBugButton"),
             S: Strings
         });
         var $panelHtml = $(panelHtml);
-        $panelHtml.find(".git-available").hide();
-
-        if (!Preferences.get("showBashButton")) {
-            $panelHtml.find(".git-bash").remove();
-        }
-
-        if (!Preferences.get("showReportBugButton")) {
-            $panelHtml.find(".git-bug").remove();
-        }
+        $panelHtml.find(".git-available, .git-not-available").hide();
 
         gitPanel = PanelManager.createBottomPanel("brackets-git.panel", $panelHtml, 100);
 

--- a/templates/git-panel.html
+++ b/templates/git-panel.html
@@ -85,9 +85,9 @@
                 <button title="{{S.TOOLTIP_PUSH}}" class="btn small git-push"><i class="octicon octicon-repo-push"></i></button>
             </div>
             <div class="btn-group">
-                <button title="{{S.TOOLTIP_OPEN_BASH}}" class="btn small git-bash"><i class="octicon octicon-terminal"></i></button>
+                {{#showBashButton}}<button title="{{S.TOOLTIP_OPEN_BASH}}" class="btn small git-bash"><i class="octicon octicon-terminal"></i></button>{{/showBashButton}}
                 <button title="{{S.GIT_SETTINGS}}" class="btn small git-settings"><i class="octicon octicon-settings"></i></button>
-                <button title="{{S.TOOLTIP_BUG}}" class="btn small git-bug"><i class="octicon octicon-bug"></i></button>
+                {{#showReportBugButton}}<button title="{{S.TOOLTIP_BUG}}" class="btn small git-bug"><i class="octicon octicon-bug"></i></button>{{/showReportBugButton}}
             </div>
         </div>
         <a href="#" class="close">&times;</a>


### PR DESCRIPTION
Removed hacks to hide/show buttons and fixed the little visual glitch that was making the buttons ".git-not-available" visible for few seconds during the loading of the panel even if the project was an already inited repository.
