### PR TITLE
Fix empty history bug

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -261,6 +261,8 @@ define(function (require) {
             doc,
             file;
 
+        $historyList = $tableContainer.find("#git-history-list");
+
         if (currentHistoryMode !== newHistoryMode) {
             // we are switching the modes so enable
             historyEnabled = true;


### PR DESCRIPTION
This fixes a not yet reported bug. Steps:
1. Open history
2. Make changes to the file (maybe whitespace) and save (the changes table is shown)
3. Try to open history again
