### PR TITLE
Various improvements of Diffs

### DIFF
--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -213,6 +213,7 @@ define({
     USE_REBASE:                         "Use REBASE",
     USER_DATE_FORMAT:                   "Own date format (<a href='http://momentjs.com/docs/#/displaying/format/'>Syntax</a>)",
     USE_GITFTP:                         "Use Git-FTP",
+    USE_VERBOSE_DIFF:                   "Show verbose output in diffs",
     USING_GIT_VERSION:                  "Git version",
     VIEW_AUTHORS_SELECTION:             "View authors of selection",
     VIEW_AUTHORS_FILE:                  "View authors of file"

--- a/src/Preferences.js
+++ b/src/Preferences.js
@@ -22,6 +22,7 @@ define(function (require, exports, module) {
         "dateFormat": {                     "type": "string",            "value": null              },
         "showReportBugButton": {            "type": "boolean",           "value": true              },
         "enableAdvancedFeatures": {         "type": "boolean",           "value": false             },
+        "useVerboseDiff": {                 "type": "boolean",           "value": false             },
         // shortcuts
         "panelShortcut": {                  "type": "string",            "value": "Ctrl-Alt-G"      },
         "commitCurrentShortcut": {          "type": "string",            "value": null              },

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -32,33 +32,74 @@ define(function (require, exports, module) {
 
     function formatDiff(diff) {
         var rv      = [],
-            tabSize = Preferences.getGlobal("tabSize");
+            tabSize = Preferences.getGlobal("tabSize"),
+            verbose = Preferences.get("useVerboseDiff");
 
         diff.split("\n").forEach(function (line) {
             if (line === " ") { line = ""; }
 
-            var lineClass;
-            if (line[0] === "+") {
+            var lineClass   = "",
+                pushLine    = true,
+                $newBlock   = $(null),
+                $separator  = $(null);
+
+            if (line.match(/index\s[A-z0-9]{7}..[A-z0-9]{7}/)) {
+                if (!verbose) {
+                    pushLine = false;
+                }
+            } else if (line.substr(0, 3) === "+++" || line.substr(0, 3) === "---" && !verbose) {
+                pushLine = false;
+            } else if (line[0] === "+" && line[1] !== "+") {
                 lineClass = "added";
-            } else if (line[0] === "-") {
+                line = line.substring(1);
+            } else if (line[0] === "-" && line[1] !== "-") {
                 lineClass = "removed";
+                line = line.substring(1);
+            } else if (line[0] === " ") {
+                lineClass = "unchanged";
+                line = line.substring(1);
             } else if (line.indexOf("@@") === 0) {
                 lineClass = "position";
             } else if (line.indexOf("diff --git") === 0) {
                 lineClass = "diffCmd";
+                $newBlock = $("<th/>")
+                                .addClass("meta")
+                                .html("<td/>")
+                                .find("td")
+                                    .text(line.split("b/")[1])
+                                .end();
+                $separator = $("<tr/>").addClass("separator");
+                if (!verbose) {
+                    pushLine = false;
+                }
             }
 
             line = _.escape(line).replace(/\s/g, "&nbsp;");
             line = line.replace(/(&nbsp;)+$/g, function (trailingWhitespace) {
                 return "<span class='trailingWhitespace'>" + trailingWhitespace + "</span>";
             });
-            var $line = $("<pre/>")
-                            .attr("style", "tab-size:" + tabSize)
-                            .html(line.length > 0 ? line : "&nbsp;");
-            if (lineClass) { $line.addClass(lineClass); }
-            rv.push($line);
+            var $line = $("<tr/>")
+                            .addClass("diff-row")
+                            .addClass(lineClass)
+                            .html("<td/>")
+                            .find("td")
+                                .html("<pre/>")
+                                .find("pre")
+                                    .attr("style", "tab-size:" + tabSize)
+                                    .html(line.length > 0 ? line : "&nbsp;")
+                                .end()
+                            .end();
+
+            if ($newBlock.length) {
+                rv.push($separator);
+                rv.push($newBlock);
+            }
+            if (pushLine) {
+                rv.push($line);
+            }
         });
-        return rv;
+        var $diff = $("<table/>");
+        return $diff.html(rv);
     }
 
     function askQuestion(title, question, options) {

--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -523,10 +523,12 @@
 // nice, formatted and colored diff
 .commit-diff {
     .selectable-text();
+    cursor: text;
     code, pre {
         background: none;
         border: none;
-        padding: 0 3px 2px;
+        padding: 0 3px;
+        margin: 0;
         font-family: 'SourceCodePro', monospace;
     }
     background-color: @almostWhite;
@@ -534,27 +536,76 @@
     border-radius: 3px;
     margin-bottom: 1em;
     overflow: auto;
-    padding: 7px 10px;
-    pre {
+    padding: 0;
+    table {
+        width: 100%;
+        tbody tr:nth-child(even) td,
+        tbody tr:nth-child(odd)  td,
+        tbody tr:nth-child(even) th,
+        tbody tr:nth-child(odd)  th {
+            background: none;
+            padding: 0;
+        }
+    }
+    tr {
         border: none;
-        border-radius: 0px;
         margin: 0px;
-        padding: 0px;
+        padding: 1px 0;
         white-space: nowrap;
         &.added {
-            color: @green-text;
+            &, & pre {
+                background-color: @lgreen-background;
+            }
+            pre:before {
+                content: "+";
+            }
         }
         &.removed {
-            color: @red-text;
+            &, & pre {
+                background-color: @lred-background;
+            }
+            pre:before {
+                content: "-";
+            }
+        }
+        &.unchanged {
+            pre:before {
+                content: "\0A0"; // &nbsp;
+            }
         }
         &.diffCmd {
             color: @blue-text;
         }
         &.position {
-            color: @orange-text;
+            &, & pre {
+                color: @gray-text;
+                background-color: @lgray-background;
+            }
         }
         .trailingWhitespace {
-            background-color: @red-background;
+            &, & pre {
+                background-color: @red-background;
+            }
+        }
+        pre {
+            white-space: nowrap;
+        }
+    }
+    .meta {
+        &:only-of-type {
+            display: none;
+        }
+        td {
+            padding: 10px;
+            border-bottom: 1px solid #d8d8d8;
+            color: @blue-text;
+            font-weight: bold;
+        }
+    }
+    .separator {
+        height: 20px;
+        &:first-child {
+            display: none;
         }
     }
 }

--- a/styles/colors.less
+++ b/styles/colors.less
@@ -15,3 +15,9 @@
 @blue-background:   #E0F0FA;
 @orange:            #E3B551;
 @orange-text:       #e28200;
+
+// Diff colors (`l` stands for "light")
+@gray-text:         #999999;
+@lgray-background:  #F0F0F7;
+@lgreen-background: #DBFFDB;
+@lred-background:   #FFDBDB;

--- a/styles/history.less
+++ b/styles/history.less
@@ -130,6 +130,63 @@
         li>a {
             margin: 10px;
             background: #E6E6E6;
+            margin-bottom: 0;
+            &:hover:not(.active) {
+                background: #ebebeb;
+            }
+        }
+        .commit-diff {
+            overflow: hidden;
+            max-height: 0px;
+            margin: 10px;
+            opacity: 0;
+            transition: all ease 0.3s;
+            transition-property: padding, height, opacity;
+            padding-top: 0;
+            padding-bottom: 0;
+            border-top: 0;
+            margin-top: 0px;
+            border-radius: 0 0 4px 4px;
+            border-color: #ddd;
+            .separator, .meta {
+                display: none;
+            }
+        }
+        .active+.commit-diff {
+            max-height: 99999px;
+            padding: 10px;
+            opacity: 1;
+            border-color: @tc-gray-component-border;
+        }
+        .opened {
+            display: none;
+            margin-top: 7px;
+        }
+        .closed {
+            display: inline-block;
+            margin-top: 5px;
+        }
+        .active {
+            background: @almostWhite;
+            border: 1px solid @tc-gray-component-border;
+            margin-bottom: 0;
+            border-bottom: 0;
+            border-radius: 4px 4px 0 0;
+            a {
+                border: none;
+                background-color: transparent;
+            }
+            .opened {
+                display: inline-block;
+            }
+            .closed {
+                display: none;
+            }
+        }
+        .caret.caret-right {
+            border-bottom: 4px solid transparent;
+            border-top: 4px solid transparent;
+            border-left: 4px solid #000000;
         }
     }
     .message {

--- a/templates/git-settings-dialog.html
+++ b/templates/git-settings-dialog.html
@@ -86,6 +86,14 @@
                 </div>
                 <div class="row-fluid">
                     <div class="span6">
+                        <label for="git-settings-useVerboseDiff">
+                            <input id="git-settings-useVerboseDiff" type="checkbox" settingsProperty="useVerboseDiff" />
+                            {{USE_VERBOSE_DIFF}}
+                        </label>
+                    </div>
+                </div>
+                <div class="row-fluid">
+                    <div class="span6">
                         <label for="git-settings-avatarType">
                             {{AVATAR_TYPE}}:
                         </label>


### PR DESCRIPTION
1. Now diffs don't show verbose lines (commands, logs etc) by default.
2. You can enable verbose diffs in settings.
3. and - symbols now are CSS pseudo-elements and are not copied if you want to copy part of code.
4. Now diffs use the same colors used in GitHub.
5. Little improvements on the way diffs are parsed.
6. When you parse a diff of multiple files, them are nicely separated.
7. Now diffs are formatted inside a table (this will help us when we'll want to add line-numbers and other features).

This fixes #403 #402
