### PR TITLE
UI tweaks in history viewer > actions

### DIFF
--- a/styles/brackets-git.css
+++ b/styles/brackets-git.css
@@ -219,10 +219,16 @@
   box-shadow: 0 -1px 3px 2px rgba(0, 0, 0, 0.15);
   z-index: 1;
 }
-#history-viewer > .header h1 {
+#history-viewer > .header .commit-title {
   font-size: 20px;
+  line-height: 24px;
   font-weight: 500;
   margin: 0;
+  margin-bottom: 1em;
+  width: 90%;
+}
+#history-viewer > .header .close {
+  margin: 6px 5px 0 0;
 }
 #history-viewer > .header .commit-hash,
 #history-viewer > .header .commit-author {
@@ -236,7 +242,7 @@
 }
 #history-viewer > .header .actions {
   float: right;
-  margin: 8px 0 10px 10px;
+  margin: -10px;
 }
 #history-viewer > .header .actions > * {
   margin-right: 15px;

--- a/styles/history.less
+++ b/styles/history.less
@@ -92,10 +92,16 @@
             box-shadow: 0 -1px 3px 2px rgba(0, 0, 0, 0.15);
             z-index: 1;
         }
-        h1 {
+        .commit-title {
             font-size: 20px;
+            line-height: 24px;
             font-weight: 500;
             margin: 0;
+            margin-bottom: 1em;
+            width: 90%
+        }
+        .close {
+            margin: 6px 5px 0 0;
         }
         .commit-hash, .commit-author {
             margin-right: 10px;
@@ -107,7 +113,7 @@
         }
         .actions {
             float: right;
-            margin: 8px 0 10px 10px;
+            margin: -10px;
             >* {
                 margin-right: 15px;
                 display: inline-block;

--- a/templates/history-viewer.html
+++ b/templates/history-viewer.html
@@ -1,8 +1,25 @@
 <div id="history-viewer" class="git-history">
     <div class="header">
         <div>
+            <a href="#" class="close">&times;</a>
+            <h1 class="commit-title selectable-text"><span>{{commit.subject}}</span></h1>
+        </div>
+        <div class="commitBody">{{{bodyMarkdown}}}</div>
+        <div>
+            <span class="commit-author">
+                <div class="commit-author-avatar">
+                    {{#useBwAvatar}}<span class="avatar-bw text" style="{{commit.cssAvatar}}">{{commit.avatarLetter}}</span>{{/useBwAvatar}}
+                    {{#useColoredAvatar}}<span class="text" style="{{commit.cssAvatar}}">{{commit.avatarLetter}}</span>{{/useColoredAvatar}}
+                    {{#usePicture}}<img src="http://gravatar.com/avatar/{{commit.emailHash}}?size=30px&default=identicon">{{/usePicture}}
+                    {{#useIdenticon}}<img src="http://gravatar.com/avatar/{{commit.emailHash}}?size=30px&default=identicon&f=y">{{/useIdenticon}}
+                </div>
+                <span class="commit-author-name">{{commit.author}}</span>
+            </span>
+            <span class="commit-hash" data-hash="{{commit.hash}}">
+                <i class="octicon octicon-git-commit"></i><span class="selectable-text">{{commit.hashShort}}</span>
+                <a href="#" class="git-extend-sha">&hellip;</a>
+            </span>
             <div class="actions">
-                <a href="#" class="close">&times;</a><br />
                 {{#enableAdvancedFeatures}}
                 <button class="git-advanced-features btn-checkout btn" title="{{Strings.TOOLTIP_CHECKOUT_COMMIT}}">{{Strings.BUTTON_CHECKOUT_COMMIT}}</button>
                 <div class="git-advanced-features dropdown">
@@ -24,22 +41,7 @@
                     <span class="collapse">{{Strings.COLLAPSE_ALL}}</span>
                 </span>
             </div>
-            <h1 class="commit-title selectable-text"><span>{{commit.subject}}</span></h1>
         </div>
-        <div class="commitBody">{{{bodyMarkdown}}}</div>
-        <span class="commit-author">
-            <div class="commit-author-avatar">
-                {{#useBwAvatar}}<span class="avatar-bw text" style="{{commit.cssAvatar}}">{{commit.avatarLetter}}</span>{{/useBwAvatar}}
-                {{#useColoredAvatar}}<span class="text" style="{{commit.cssAvatar}}">{{commit.avatarLetter}}</span>{{/useColoredAvatar}}
-                {{#usePicture}}<img src="http://gravatar.com/avatar/{{commit.emailHash}}?size=30px&default=identicon">{{/usePicture}}
-                {{#useIdenticon}}<img src="http://gravatar.com/avatar/{{commit.emailHash}}?size=30px&default=identicon&f=y">{{/useIdenticon}}
-            </div>
-            <span class="commit-author-name">{{commit.author}}</span>
-        </span>
-        <span class="commit-hash" data-hash="{{commit.hash}}">
-            <i class="octicon octicon-git-commit"></i><span class="selectable-text">{{commit.hashShort}}</span>
-            <a href="#" class="git-extend-sha">&hellip;</a>
-        </span>
     </div>
     <div class="body">
         <div class="table-striped tab-content">


### PR DESCRIPTION
Fix the spacement in the commit subject when this have more that one line and repositioned the actions block and close bottom.

![captura de tela 2014-04-16 as 12 18 04](https://cloud.githubusercontent.com/assets/1726914/2721378/f04321a8-c57a-11e3-8e27-757000653526.png)
![captura de tela 2014-04-16 as 12 18 19](https://cloud.githubusercontent.com/assets/1726914/2721381/f397d376-c57a-11e3-8eba-416ee5c92771.png)
