### PR TITLE
Better parsing of .gitignore

### DIFF
--- a/src/GitIgnore.js
+++ b/src/GitIgnore.js
@@ -1,0 +1,91 @@
+define(function (require, exports) {
+    "use strict";
+
+    var _                 = brackets.getModule("thirdparty/lodash"),
+        FileSystem        = brackets.getModule("filesystem/FileSystem");
+
+    var EventEmitter      = require("src/EventEmitter"),
+        Events            = require("src/Events"),
+        Promise           = require("bluebird"),
+        Preferences       = require("./Preferences"),
+        Utils             = require("src/Utils");
+
+    var ignoreEntries = [];
+
+    function refreshIgnoreEntries() {
+        return new Promise(function (resolve) {
+
+            if (!Preferences.get("markModifiedInTree")) {
+                return resolve();
+            }
+
+            var projectRoot = Utils.getProjectRoot();
+
+            FileSystem.getFileForPath(projectRoot + ".gitignore").read(function (err, content) {
+                if (err) {
+                    ignoreEntries = [];
+                    return resolve();
+                }
+
+                ignoreEntries = _.compact(_.map(content.split("\n"), function (line) {
+                    var type = "deny",
+                        isNegative,
+                        leadingSlash,
+                        regex;
+
+                    line = line.trim();
+                    if (!line || line.indexOf("#") === 0) {
+                        return;
+                    }
+
+                    isNegative = line.indexOf("!") === 0;
+                    if (isNegative) {
+                        line = line.slice(1);
+                        type = "accept";
+                    }
+                    if (line.indexOf("\\") === 0) {
+                        line = line.slice(1);
+                    }
+                    if (line.indexOf("/") === 0) {
+                        line = line.slice(1);
+                        leadingSlash = true;
+                    }
+
+                    line = line.replace(/[^*]$/, "$&**");
+
+                    regex = projectRoot + (leadingSlash ? "" : "**") + line;
+                    // NOTE: We cannot use StringUtils.regexEscape() here because we don't wanna replace *
+                    regex = regex.replace(/([.?+\^$\[\]\\(){}|\-])/g, "\\$1");
+                    regex = regex.replace(/\*\*$/g, "(.{0,})").replace(/\*\*/g, "(.+)").replace(/\*/g, "([^/]+)");
+                    regex = "^" + regex + "$";
+
+                    console.log(regex);
+                    return {regexp: new RegExp(regex), type: type};
+                }));
+
+                return resolve();
+            });
+        });
+    }
+
+    function isIgnored(path) {
+        var ignored = false;
+        _.forEach(ignoreEntries, function (entry) {
+            if (entry.regexp.test(path)) {
+                ignored = (entry.type === "deny");
+            }
+        });
+        return ignored;
+    }
+
+    EventEmitter.on(Events.GIT_ENABLED, function () {
+        refreshIgnoreEntries();
+    });
+    EventEmitter.on(Events.GIT_DISABLED, function () {
+        ignoreEntries = [];
+    });
+
+    exports.isIgnored               = isIgnored;
+    exports.refreshIgnoreEntries    = refreshIgnoreEntries;
+
+});


### PR DESCRIPTION
This fixes #476.
The parsing code was completely rewritten, and I'd claim it matches the git behaviour (see ref 1) in most of the cases.
I used some parts of gitignore-parser (ref 2) as an inspiration.
While I was developing this, I found the git command `git ls-files --ignored --exclude-from=.gitignore` (see ref 3 and 4), which is doing just the same, but on git's side ;)
It would make our parsing even better, so I'd like to see it called from brackets-git.

References:
1. http://git-scm.com/docs/gitignore
2. https://github.com/codemix/gitignore-parser/blob/master/lib/index.js
3. https://www.kernel.org/pub/software/scm/git/docs/git-ls-files.html
4. http://stackoverflow.com/a/467053/3455922
