### PR TITLE
escape filename to fix Refreshing gutter failed error

### DIFF
--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -13,7 +13,7 @@ define(function (require, exports) {
     var _           = brackets.getModule("thirdparty/lodash"),
         FileSystem  = brackets.getModule("filesystem/FileSystem"),
         FileUtils   = brackets.getModule("file/FileUtils"),
-        StringUtils = brackets.getModule("file/FileUtils");
+        StringUtils = brackets.getModule("utils/StringUtils");
 
     // Local modules
     var Promise       = require("bluebird"),


### PR DESCRIPTION
This fixes error "Refreshing gutter failed!" error with unescaped filenames, e.g.:
    SyntaxError: Invalid regular expression: /^(\S)(.)\s+(cpp/zzzB++/aqqq)$/: Nothing to repeat
