### PR TITLE
Fix commit diff cursor

### DIFF
--- a/styles/brackets-git.css
+++ b/styles/brackets-git.css
@@ -539,7 +539,6 @@
   -ms-user-select: text;
   -o-user-select: text;
   user-select: text;
-  cursor: text;
   background-color: #f5f5f5;
   border: 1px solid #b2b5b5;
   border-radius: 3px;
@@ -566,6 +565,7 @@
 }
 .commit-diff table {
   width: 100%;
+  cursor: text;
 }
 .commit-diff table tbody tr.meta-file th {
   border-top: 0;

--- a/styles/commit-diff.less
+++ b/styles/commit-diff.less
@@ -4,7 +4,6 @@
     @lineHeight: 15px;
     .code-font();
     .selectable-text();
-    cursor: text;
     code, pre {
         .code-font();
         background-color: none;
@@ -31,6 +30,7 @@
     }
     table {
         width: 100%;
+        cursor: text;
         tbody {
             tr.meta-file {
                 th {


### PR DESCRIPTION
This restores the default cursor for the commit diff scrollbars.
