### PR TITLE
Remove panel table margin-bottom

### DIFF
--- a/styles/brackets-git.css
+++ b/styles/brackets-git.css
@@ -791,6 +791,9 @@
 #git-panel .toolbar {
   overflow: visible;
 }
+#git-panel table {
+  margin-bottom: 0;
+}
 #git-panel .git-edited-list td {
   vertical-align: middle;
 }

--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -121,6 +121,9 @@
     .toolbar {
         overflow: visible;
     }
+    table {
+        margin-bottom: 0;
+    }
     .git-edited-list td {
         vertical-align: middle;
     }


### PR DESCRIPTION
This overrides the default table margin-bottom (seen in the screenshot) for the git panel.

![panel-table-margin](https://cloud.githubusercontent.com/assets/2069528/3138331/17987d16-e885-11e3-9b2e-d74ad43082b3.png)
