### PR TITLE
Add i18n key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "url": "https://github.com/zaggino/brackets-git/issues",
         "email": "zaggino@gmail.com"
     },
+    "i18n": ["en", "en-uk", "de", "fr", "it", "pt-br", "zh-cn"],
 
     "engines": {
         "brackets": ">=0.40.0"


### PR DESCRIPTION
Implemented via adobe/brackets#7995 and displayed in the Extension Manager beginning with Release 0.42
