### PR TITLE
Make switch branch clickable area larger

### DIFF
--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -73,6 +73,8 @@
         .switch-branch {
             display: inline-block;
             width: 100%;
+            padding: 5px 0;
+            margin: -5px 0;
         }
         .trash-icon, .merge-branch {
             position: absolute;


### PR DESCRIPTION
This is a small usability improvement that allows you to click on the white space above and below the branch text.
