### PR TITLE
Corrects the OS X “Terminal got an error: Can’t get window 1"

### DIFF
--- a/shell/terminal.osa
+++ b/shell/terminal.osa
@@ -4,9 +4,9 @@ on run argv
     set new_cmd to 0
     tell app "System Events"
         if "Terminal" is not in name of processes then
-            launch application "Terminal"
+            launch app "Terminal"
 
-            tell application "Terminal"
+            tell app "Terminal"
                 activate
                 do script ""
             end tell
@@ -15,7 +15,7 @@ on run argv
         end if
     end tell
 
-    tell application "Terminal"
+    tell app "Terminal"
         if (new_cmd) is 1 then
             do script "cd " & dir in window 1
         else


### PR DESCRIPTION
Code was calling the Terminal process rather than the application; also `set frontmost to true` just doesn’t seem to do what it’s supposed to do. Touching the terminal with a dummy `do script`seems to get the job done.

This has only been tested in Yosemite, and functions properly. Should likely be tested in older versions as well. 

Cheers, and thanks!
