### PR TITLE
Replacing brackets.fs.stat() with FileSystem.resolve()

### DIFF
--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -925,10 +925,10 @@ define(function (require, exports) {
                     Utils.consoleDebug("Checking path for .git: " + path);
 
                     return new Promise(function (resolve) {
-                        // use fs.stat here to avoid putting the entry to the brackets's index
-                        brackets.fs.stat(path + "/.git", function (err, stat) {
 
-                            var exists = err ? false : (stat.isFile() || stat.isDirectory());
+                        FileSystem.resolve(path + "/.git", function (err, item, stat) {
+
+                            var exists = err ? false : (stat.isFile || stat.isDirectory);
 
                             if (exists) {
                                 Utils.consoleDebug("Found .git in path: " + path);


### PR DESCRIPTION
Hi @zaggino !
I created a branch for fixing the issue #853 . By using the deprecated `brackets.fs` API, this extension doesn't work on the Intel XDK. 
I used `FileSystem.resolve` instead of `brackets.fs.stat` if you don't mind to have one more entry on the index map, since we have only one .git/ folder per project. File watchers shouldn't be a problem, but if you think that this is not a good solution, we can use `fs.exists` from Node APIs.

Thanks
