### PR TITLE
Update various styles

### DIFF
--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -190,6 +190,7 @@
     }
     .octicon:not(:only-child) {
         margin-right: 5px;
+        vertical-align: -1px;
     }
     .btn-group.open .dropdown-toggle {
         background-color: @bc-btn-bg;
@@ -301,20 +302,15 @@
         background-color: @bc-bg-highlight !important;
 
         .dark & {
-            background-color:@dark-bc-bg-highlight !important;
+            background-color: @dark-bc-bg-highlight !important;
         }
     }
 
-    // Remove this once https://github.com/adobe/brackets/pull/8793/files is merged.
     .btn.active:not([disabled]) {
-        background-image: none;
-        background-color: @bc-bg-highlight;
-        box-shadow: inset 0 1px 0 @bc-shadow-small;
-        color: @bc-text-alt;
+        color: @bc-text-link;
 
         .dark & {
-            background-color:@dark-bc-bg-highlight;
-            box-shadow: inset 0 1px 0 @dark-bc-shadow-small;
+            background-color: @dark-bc-bg-highlight;
             color: @dark-bc-text-alt;
         }
     }

--- a/styles/history.less
+++ b/styles/history.less
@@ -134,6 +134,9 @@
                 margin-right: 10px;
                 display: inline-block;
             }
+            .git-reset-label + .caret {
+                margin-left: 5px;
+            }
             .dropdown-menu {
                 left: auto;
                 right: 0;
@@ -148,7 +151,9 @@
         overflow-y: scroll;
         li > a {
             background: @bc-btn-bg;
-            border: none;
+            border: 1px solid transparent;
+            border-right: 0;
+            border-left: 0;
             color: @bc-text;
             margin: 10px;
             margin-bottom: 0;
@@ -171,7 +176,7 @@
             padding-bottom: 0;
             border-top: 0;
             margin-top: 0px;
-            border-radius: 0 0 4px 4px;
+            border-radius: 0 0 3px 3px;
             border-color: @bc-btn-border;
             margin-bottom: 0;
 
@@ -228,6 +233,7 @@
             border-left: 4px solid transparent;
             border-right: 4px solid transparent;
             border-top: 5px solid @bc-text;
+            margin-right: 2px;
 
             .dark & {
                 border-top: 5px solid @dark-bc-text;
@@ -237,6 +243,8 @@
             border-bottom: 4px solid transparent;
             border-top: 4px solid transparent;
             border-left: 5px solid @bc-text;
+            margin-right: -1px;
+            margin-left: 3px;
 
             .dark & {
                 border-left: 5px solid @dark-bc-text;
@@ -248,7 +256,8 @@
         .commit-files {
             padding: 0 20px;
             .openFile, .difftool {
-                margin-left: 20px;
+                vertical-align: -1px;
+                margin-left: 10px;
                 cursor: pointer;
                 opacity: 0.7;
             }
@@ -280,6 +289,9 @@
         }
         .expand {
             vertical-align: middle;
+        }
+        span.expand {
+            margin-left: 2px;
         }
         &.opened {
             .expand {


### PR DESCRIPTION
Some minor visual tweaks:
- improve git panel text vertical alignment
- fix git panel history buttons text color (not sure how/when this regressed)
- add "Reset index" caret spacing
- add "Expand all" icon spacing (now consistent with "Collapse all")
- centered history viewer diff expand/collapse carets
- reduced open-file/difftool spacing and improved vertical alignment
- clicking a file to expand/collapse the diff (in history viewer) no longer produces a vertical shift effect

**Before:**
![Before](https://cloud.githubusercontent.com/assets/2069528/6635570/cd012d26-c924-11e4-944f-a2c89fccd750.png)

**After:**
![After](https://cloud.githubusercontent.com/assets/2069528/6635572/cef1d374-c924-11e4-9f39-065b89ea4804.png)