### PR TITLE
add commit date to file history viewer

### DIFF
--- a/templates/history-viewer.html
+++ b/templates/history-viewer.html
@@ -18,6 +18,9 @@
                 <i class="octicon octicon-git-commit"></i>&nbsp;<span class="selectable-text">{{commit.hashShort}}</span>
                 <a href="#" class="git-extend-sha">&hellip;</a>
             </span>
+            <span class="commit-time">
+                <i class="octicon octicon-calendar"></i>&nbsp;<span class="selectable-text">{{commit.date}}</span>
+            </span>
             <div class="actions">
                 {{#enableAdvancedFeatures}}
                 <button class="git-advanced-features btn-checkout btn" title="{{Strings.TOOLTIP_CHECKOUT_COMMIT}}">{{Strings.BUTTON_CHECKOUT_COMMIT}}</button>


### PR DESCRIPTION
Here’s an idea I thought potentially useful: showing the commit’s actual date along with the author and hash info. But I’m not familiar enough with Javascript templating to get the right value in here. This commit results in `Object object` being shown in place of the actual date and time.