### PR TITLE
Issue 995

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -523,22 +523,14 @@ define(function (require, exports) {
     function _getDiffForUntrackedFiles(files) {
         var fileArray = [];
         fileArray = fileArray.concat(files);
-        return new Promise(function (resolve) {
-            return Git.stage(fileArray, false).then(function () {
-                return new Promise(function () {
-                    return Git.getDiffOfStagedFiles().then(function (diff) {
-                        return Git.resetIndex().then(function () {
-                            resolve(diff);
-                        });
-                    });
-                });
-            }).catch(function () {
-                return Git.resetIndex().then(function () {
-                    return Git.getDiffOfAllIndexFiles(fileArray);
-                }).catch(function (err) {
-                    ErrorHandler.showError(err, "Unable to reset index to calculate diff.");
-                });
-            });
+        var diff;
+        return Git.stage(fileArray, false).then(function () {
+            return Git.getDiffOfStagedFiles();
+        }).then(function (_diff) {
+            diff = _diff;
+            return Git.resetIndex();
+        }).then(function () {
+            return diff;
         });
     }
 

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -526,15 +526,17 @@ define(function (require, exports) {
         return new Promise(function (resolve) {
             return Git.stage(fileArray, false).then(function () {
                 return new Promise(function () {
-                    Git.getDiffOfStagedFiles().then(function (diff) {
-                        Git.resetIndex().then(function () {
+                    return Git.getDiffOfStagedFiles().then(function (diff) {
+                        return Git.resetIndex().then(function () {
                             resolve(diff);
                         });
                     });
                 });
             }).catch(function () {
-                Git.resetIndex().then(function () {
+                return Git.resetIndex().then(function () {
                     return Git.getDiffOfAllIndexFiles(fileArray);
+                }).catch(function (err) {
+                    ErrorHandler.showError(err, "Unable to reset index to calculate diff.");
                 });
             });
         });

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -785,6 +785,14 @@ define(function (require, exports) {
         });
     }
 
+    function getDiffOfUntrackedFile(file) {
+        var args = ["diff", "--no-ext-diff", "--no-color", "--", "/dev/null"];
+        args = args.concat(file);
+        return git(args, {
+            timeout: false // never timeout this
+        });
+    }
+
     function getListOfStagedFiles() {
         return git(["diff", "--no-ext-diff", "--no-color", "--staged", "--name-only"], {
             timeout: false // never timeout this
@@ -1050,6 +1058,7 @@ define(function (require, exports) {
     exports.getLastCommitMessage      = getLastCommitMessage;
     exports.mergeBranch               = mergeBranch;
     exports.getDiffOfAllIndexFiles    = getDiffOfAllIndexFiles;
+    exports.getDiffOfUntrackedFile    = getDiffOfUntrackedFile;
     exports.getDiffOfStagedFiles      = getDiffOfStagedFiles;
     exports.getListOfStagedFiles      = getListOfStagedFiles;
     exports.getBlame                  = getBlame;

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -785,14 +785,6 @@ define(function (require, exports) {
         });
     }
 
-    function getDiffOfUntrackedFile(file) {
-        var args = ["diff", "--no-ext-diff", "--no-color", "--", "/dev/null"];
-        args = args.concat(file);
-        return git(args, {
-            timeout: false // never timeout this
-        });
-    }
-
     function getListOfStagedFiles() {
         return git(["diff", "--no-ext-diff", "--no-color", "--staged", "--name-only"], {
             timeout: false // never timeout this
@@ -1058,7 +1050,6 @@ define(function (require, exports) {
     exports.getLastCommitMessage      = getLastCommitMessage;
     exports.mergeBranch               = mergeBranch;
     exports.getDiffOfAllIndexFiles    = getDiffOfAllIndexFiles;
-    exports.getDiffOfUntrackedFile    = getDiffOfUntrackedFile;
     exports.getDiffOfStagedFiles      = getDiffOfStagedFiles;
     exports.getListOfStagedFiles      = getListOfStagedFiles;
     exports.getBlame                  = getBlame;


### PR DESCRIPTION
In the Brackets Git extension, a diff is used to review the changes you are about to commit, this means that on our flow it is important that all changes--even untracked files--must have a diff. Without a diff of untracked files the user gets the feeling that none of these new file will get committed.

After doing some investigation on how git diff works, I found that the only way to get a diff of a untracked files is to compare the file against /dev/null which did not sound like a good cross-platform solution.  Also I tried to run the command via brackets git but it was not returning the actual diff. 

So, our solution requires flows for two cases:

* Commit all: We need to check the status of the files that are candidates for the commit and check for untracked files.  If there are untracked files we will stage all the changes and do a diff of all files.  Once we have the diff we can unstage all the changes and then show the commit dialog using the diff.
* Single commit: In this case we already know the status of the file, so if it is untracked we stage it, do the diff and unstage and show the commit dialog using the diff.
