### PR TITLE
Fix gitignore filtering

### DIFF
--- a/src/ProjectTreeMarks.js
+++ b/src/ProjectTreeMarks.js
@@ -92,7 +92,7 @@ define(function (require) {
                 // are external files with the same name as a project file
                 regex = regexEscape(gitRoot) + (leadingSlash ? "" : "((.+)/)?") + regexEscape(line) + (trailingSlash ? "" : "(/.{0,})?");
                 // replace all the possible asterisks
-                regex = regex.replace(/\*\*$/g, "(.{0,})").replace(/(\*\*|\*$)/g, "(.+)").replace(/\*/g, "([^/]+)");
+                regex = regex.replace(/\*\*$/g, "(.{0,})").replace(/(\*\*|\*$)/g, "(.+)").replace(/\*/g, "([^/]*)");
                 regex = "^" + regex + "$";
 
                 return {

--- a/src/ProjectTreeMarks.js
+++ b/src/ProjectTreeMarks.js
@@ -46,7 +46,7 @@ define(function (require) {
     function refreshIgnoreEntries() {
         function regexEscape(str) {
             // NOTE: We cannot use StringUtils.regexEscape() here because we don't wanna replace *
-            return str.replace(/([.?+\^$\\(){}|\-])/g, "\\$1");
+            return str.replace(/([.?+\^$\\(){}|])/g, "\\$1");
         }
 
         return loadIgnoreContents().then(function (content) {

--- a/src/ProjectTreeMarks.js
+++ b/src/ProjectTreeMarks.js
@@ -46,7 +46,7 @@ define(function (require) {
     function refreshIgnoreEntries() {
         function regexEscape(str) {
             // NOTE: We cannot use StringUtils.regexEscape() here because we don't wanna replace *
-            return str.replace(/([.?+\^$\[\]\\(){}|\-])/g, "\\$1");
+            return str.replace(/([.?+\^$\\(){}|\-])/g, "\\$1");
         }
 
         return loadIgnoreContents().then(function (content) {


### PR DESCRIPTION
Fixes #1038

1. Remove escaping of `[` and `]`
2. Change folder checks from 1 or more to 0 or more. 