### PR TITLE
Typos in GIT-FTP.md

### DIFF
--- a/docs/GIT-FTP.md
+++ b/docs/GIT-FTP.md
@@ -2,8 +2,8 @@
 
 **Brackets Git** offers built-in support for **Git-FTP**, an FTP extension which allows sync repositories using FTP, to install this extension follow these steps:
 
-1. Download the **Git-FTP** script [from this link](/docs/src/git-ftp) (N.B. the script has not an extension)
+1. Download the **Git-FTP** script [from this link](/docs/src/git-ftp) (N.B.: the script does not have an extension)
 2. Move the downloaded script inside your Git binaries installation folder (usually `C:\Program Files\Git\bin\` on Windows, `/usr/bin` on GNU/Linux or `/usr/local/bin` on OS X)
 3. Open **Brackets Git** settings and enable Git-FTP.
 
-Now you should be able to use **Git-FTP** thorugh **Brackets Git**.
+Now you should be able to use **Git-FTP** through **Brackets Git**.


### PR DESCRIPTION
Fixed misspelling of "through" and clarified the NB.