### PR TITLE
Added authentication to Clone dialog

### DIFF
--- a/src/NoRepo.js
+++ b/src/NoRepo.js
@@ -101,9 +101,9 @@ define(function (require) {
                     }
 
                     // do the clone
-                    q = q.then(function() {
+                    q = q.then(function () {
                         return ProgressDialog.show(Git.clone(remoteUrl, "."));
-                    }).catch(function(err) {
+                    }).catch(function (err) {
                         ErrorHandler.showError(err, "Cloning remote repository failed!");
                     });
 

--- a/src/NoRepo.js
+++ b/src/NoRepo.js
@@ -7,12 +7,12 @@ define(function (require) {
 
     // Local modules
     var Promise         = require("bluebird"),
-        Strings         = require("strings"),
         ErrorHandler    = require("src/ErrorHandler"),
         Events          = require("src/Events"),
         EventEmitter    = require("src/EventEmitter"),
         ExpectedError   = require("src/ExpectedError"),
         ProgressDialog  = require("src/dialogs/Progress"),
+        CloneDialog     = require("src/dialogs/Clone"),
         Git             = require("src/git/Git"),
         Preferences     = require("src/Preferences"),
         Utils           = require("src/Utils");
@@ -92,12 +92,36 @@ define(function (require) {
         $cloneButton.prop("disabled", true);
         isProjectRootEmpty().then(function (isEmpty) {
             if (isEmpty) {
-                return Utils.askQuestion(Strings.CLONE_REPOSITORY, Strings.ENTER_REMOTE_GIT_URL).then(function (remoteGitUrl) {
-                    return ProgressDialog.show(Git.clone(remoteGitUrl, "."))
-                        .then(function () {
-                            EventEmitter.emit(Events.REFRESH_ALL);
+                CloneDialog.show().then(function (cloneConfig) {
+                    var q = Promise.resolve();
+                    // put username and password into remote url
+                    var remoteUrl = cloneConfig.remoteUrl;
+                    if (cloneConfig.remoteUrlNew) {
+                        remoteUrl = cloneConfig.remoteUrlNew;
+                    }
+
+                    // do the clone
+                    q = q.then(function() {
+                        return ProgressDialog.show(Git.clone(remoteUrl, "."));
+                    }).catch(function(err) {
+                        ErrorHandler.showError(err, "Cloning remote repository failed!");
+                    });
+
+                    // restore original url if desired
+                    if (cloneConfig.remoteUrlRestore) {
+                        q = q.then(function () {
+                            return Git.setRemoteUrl(cloneConfig.remote, cloneConfig.remoteUrlRestore);
                         });
+                    }
+
+                    return q.finally(function () {
+                        EventEmitter.emit(Events.REFRESH_ALL);
+                    });
+                }).catch(function (err) {
+                    // when dialog is cancelled, there's no error
+                    if (err) { ErrorHandler.showError(err, "Cloning remote repository failed!"); }
                 });
+
             } else {
                 var err = new ExpectedError("Project root is not empty, be sure you have deleted hidden files");
                 ErrorHandler.showError(err, "Cloning remote repository failed!");

--- a/src/dialogs/Clone.js
+++ b/src/dialogs/Clone.js
@@ -19,8 +19,8 @@ define(function (require, exports) {
 
     // Implementation
     function _attachEvents($dialog) {
-        //Detect changes to URL, disable auth if not http
-        $cloneInput.on("keyup change", function() {
+        // Detect changes to URL, disable auth if not http
+        $cloneInput.on("keyup change", function () {
             var $authInputs = $dialog.find("input[name='username'],input[name='password'],input[name='saveToUrl']");
             if ($(this).val().length > 0) {
                 if (/^https?:/.test($(this).val())) {

--- a/src/dialogs/Clone.js
+++ b/src/dialogs/Clone.js
@@ -1,0 +1,79 @@
+define(function (require, exports) {
+    "use strict";
+
+    // Brackets modules
+    var Dialogs = brackets.getModule("widgets/Dialogs");
+
+    // Local modules
+    var Promise         = require("bluebird"),
+        RemoteCommon    = require("src/dialogs/RemoteCommon"),
+        Strings         = require("strings");
+
+    // Templates
+    var template            = require("text!src/dialogs/templates/clone-dialog.html"),
+        credentialsTemplate = require("text!src/dialogs/templates/credentials-template.html");
+
+    // Module variables
+    var defer,
+        $cloneInput;
+
+    // Implementation
+    function _attachEvents($dialog) {
+        //Detect changes to URL, disable auth if not http
+        $cloneInput.on("keyup change", function() {
+            var $authInputs = $dialog.find("input[name='username'],input[name='password'],input[name='saveToUrl']");
+            if ($(this).val().length > 0) {
+                if (/^https?:/.test($(this).val())) {
+                    $authInputs.prop("disabled", false);
+
+                    // Update the auth fields if the URL contains auth
+                    var auth = /:\/\/([^:]+):?([^@]*)@/.exec($(this).val());
+                    if (auth) {
+                        $("input[name=username]", $dialog).val(auth[1]);
+                        $("input[name=password]", $dialog).val(auth[2]);
+                    }
+                } else {
+                    $authInputs.prop("disabled", true);
+                }
+            } else {
+                $authInputs.prop("disabled", false);
+            }
+        });
+        $cloneInput.focus();
+    }
+
+    function show() {
+        defer = Promise.defer();
+
+        var templateArgs = {
+            modeLabel: Strings.CLONE_REPOSITORY,
+            Strings: Strings
+        };
+
+        var compiledTemplate = Mustache.render(template, templateArgs, {
+            credentials: credentialsTemplate
+        }),
+        dialog = Dialogs.showModalDialogUsingTemplate(compiledTemplate),
+        $dialog = dialog.getElement();
+
+        $cloneInput = $dialog.find("#git-clone-url");
+
+        _attachEvents($dialog);
+
+        dialog.done(function (buttonId) {
+            if (buttonId === "ok") {
+                var cloneConfig = {};
+                cloneConfig.remote = "origin";
+                cloneConfig.remoteUrl = $cloneInput.val();
+                RemoteCommon.collectValues(cloneConfig, $dialog);
+                defer.resolve(cloneConfig);
+            } else {
+                defer.reject();
+            }
+        });
+
+        return defer.promise;
+    }
+
+    exports.show = show;
+});

--- a/src/dialogs/templates/clone-dialog.html
+++ b/src/dialogs/templates/clone-dialog.html
@@ -1,0 +1,19 @@
+<div id="git-clone-dialog" class="git modal">
+    <div class="modal-header">
+        <h1 class="dialog-title">{{Strings.CLONE_REPOSITORY}}</h1>
+    </div>
+    <div class="modal-body">
+
+        <label for="git-clone-url">{{Strings.ENTER_REMOTE_GIT_URL}}</label>
+        <input type="text" class="stringInput" id="git-clone-url" />
+
+        <hr>
+
+        {{> credentials}}
+
+    </div>
+    <div class="modal-footer">
+        <button class="dialog-button btn" data-button-id="cancel">{{Strings.CANCEL}}</button>
+        <button class="dialog-button btn primary" data-button-id="ok">{{Strings.OK}}</button>
+    </div>
+</div>

--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -357,6 +357,7 @@
 #git-changelog-dialog,
 #git-question-dialog,
 #git-commit-dialog,
+#git-clone-dialog,
 #git-diff-dialog {
     .invalid {
         border-color: @red;


### PR DESCRIPTION
Fixes #707 and #1018

I added a new modal dialog js file and template for cloning. Closely based it on the Pull and Push dialogs in terms of code, but still looks familiar to the original Utils.askQuestion that handled cloning.

I replaced the Utils.askQuestion code with the new modal dialog in NoRepo.js. I looked at the Push/Pull code from Remotes.js and used the same methods and style. I removed the strings require as it's now handled in the modal dialog.

Added 1 line in the LESS file (just the ID of the modal) so that the input field is full length.

Linted everything with grunt jshint :). No errors or unhandled stuff.

![brackets-git-clone-auth](https://cloud.githubusercontent.com/assets/2722612/11519608/b61e4eb8-98ef-11e5-9117-916abe85ace5.png)
