### PR TITLE
Add counter for commits behind

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Always try to get as much relevant information from Brackets console (F12) as po
 
 When creating a new functionality which isn't noted on GitHub, please open an issue for it before working on the code as others may have hints and suggestions to consider before writing the code. Also when fixing an issue, add a comment to the issue on GitHub before working on it so it doesn't happen that two people are working on the same thing at the same time.
 
-Always check for syntax errors with `grunt jshint` or use some JSHint extension while editing the code.
+Always check for syntax errors with `grunt test` or use some JSHint extension while editing the code.
 Recommended are both [JSHint](https://github.com/cfjedimaster/brackets-jshint) and [InteractiveLinter](https://github.com/MiguelCastillo/Brackets-InteractiveLinter).
 
 ## Developing

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -799,23 +799,28 @@ define(function (require, exports) {
             $pullBtn.children("span").remove();
             $pushBtn.children("span").remove();
         };
-        clearCounts();
-        // Get the commit counts and append them to the buttons
-        var proc = Git.getCommitCounts().then(function (commits) {
+
+        // Check if there's a remote, resolve if there's not
+        var remotes = Preferences.get("defaultRemotes") || {};
+        var defaultRemote = remotes[Preferences.get("currentGitRoot")];
+        if (!defaultRemote) {
             clearCounts();
-            if (!commits) {
-                return;
-            }
+            return Promise.resolve();
+        }
+
+        // Get the commit counts and append them to the buttons
+        return Git.getCommitCounts().then(function (commits) {
+            clearCounts();
             if (commits.behind > 0) {
                 $pullBtn.append($("<span/>").text(" (" + commits.behind + ")"));
             }
             if (commits.ahead > 0) {
                 $pushBtn.append($("<span/>").text(" (" + commits.ahead + ")"));
             }
-        }).catch(function () {
+        }).catch(function (err) {
             clearCounts();
+            console.log(err);
         });
-        return proc;
     }
 
     function refresh() {

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -805,23 +805,16 @@ define(function (require, exports) {
         if (remotes) {
             defaultRemote = remotes[Preferences.get("currentGitRoot")] || defaultRemote;
         }
-        var proc = Git.fetchRemote(defaultRemote).then(function () {
-            Git.getCommitCounts().then(function (commits) {
-                clearCounts();
-                if (commits.behind > 0) {
-                    $pullBtn.append($("<span/>").text(" (" + commits.behind + ")"));
-                }
-                if (commits.ahead > 0) {
-                    $pushBtn.append($("<span/>").text(" (" + commits.ahead + ")"));
-                }
-            }).catch(function (err) {
-                clearCounts();
-                ErrorHandler.showError(err, "Error getting commit count");
-            });
-        }).catch(function (err) {
+        var proc = Git.getCommitCounts().then(function (commits) {
             clearCounts();
-            // This can error when trying to access a private repo without a login
-            console.error(err);
+            if (commits.behind > 0) {
+                $pullBtn.append($("<span/>").text(" (" + commits.behind + ")"));
+            }
+            if (commits.ahead > 0) {
+                $pushBtn.append($("<span/>").text(" (" + commits.ahead + ")"));
+            }
+        }).catch(function () {
+            clearCounts();
         });
         return proc;
     }

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -819,7 +819,7 @@ define(function (require, exports) {
             }
         }).catch(function (err) {
             clearCounts();
-            console.log(err);
+            ErrorHandler.logError(err);
         });
     }
 

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -801,7 +801,10 @@ define(function (require, exports) {
         };
         clearCounts();
         var remotes = Preferences.get("defaultRemotes");
-        var defaultRemote = remotes[Preferences.get("currentGitRoot")];
+        var defaultRemote = "origin";
+        if (remotes) {
+            defaultRemote = remotes[Preferences.get("currentGitRoot")] || defaultRemote;
+        }
         var proc = Git.fetchRemote(defaultRemote).then(function(){
             Git.getCommitCounts().then(function (commits) {
                 clearCounts();

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -792,7 +792,7 @@ define(function (require, exports) {
     }
 
     function refreshCommitCounts() {
-        // Push and Pull buttons
+        // Find Push and Pull buttons
         var $pullBtn = $gitPanel.find(".git-pull");
         var $pushBtn = $gitPanel.find(".git-push");
         var clearCounts = function () {
@@ -800,13 +800,12 @@ define(function (require, exports) {
             $pushBtn.children("span").remove();
         };
         clearCounts();
-        var remotes = Preferences.get("defaultRemotes");
-        var defaultRemote = "origin";
-        if (remotes) {
-            defaultRemote = remotes[Preferences.get("currentGitRoot")] || defaultRemote;
-        }
+        // Get the commit counts and append them to the buttons
         var proc = Git.getCommitCounts().then(function (commits) {
             clearCounts();
+            if (!commits) {
+                return;
+            }
             if (commits.behind > 0) {
                 $pullBtn.append($("<span/>").text(" (" + commits.behind + ")"));
             }

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -805,7 +805,7 @@ define(function (require, exports) {
         if (remotes) {
             defaultRemote = remotes[Preferences.get("currentGitRoot")] || defaultRemote;
         }
-        var proc = Git.fetchRemote(defaultRemote).then(function(){
+        var proc = Git.fetchRemote(defaultRemote).then(function () {
             Git.getCommitCounts().then(function (commits) {
                 clearCounts();
                 if (commits.behind > 0) {
@@ -820,7 +820,7 @@ define(function (require, exports) {
             });
         }).catch(function (err) {
             clearCounts();
-            //This can error when trying to access a private repo without a login
+            // This can error when trying to access a private repo without a login
             console.error(err);
         });
         return proc;

--- a/src/Remotes.js
+++ b/src/Remotes.js
@@ -18,7 +18,8 @@ define(function (require) {
         PullDialog      = require("src/dialogs/Pull"),
         PushDialog      = require("src/dialogs/Push"),
         Strings         = require("strings"),
-        Utils           = require("src/Utils");
+        Utils           = require("src/Utils"),
+        Panel           = require("src/Panel");
 
     // Templates
     var gitRemotesPickerTemplate = require("text!templates/git-remotes-picker.html");
@@ -330,6 +331,7 @@ define(function (require) {
             remoteName  = $remote.data("remote-name"),
             type        = $remote.data("type");
         selectRemote(remoteName, type);
+        Panel.refresh();
     });
     EventEmitter.on(Events.HANDLE_REMOTE_CREATE, function () {
         handleRemoteCreation();

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -882,9 +882,17 @@ define(function (require, exports) {
         });
     }
 
-    function getCommitsAhead() {
-        return git(["rev-list", "HEAD", "--not", "--remotes"]).then(function (stdout) {
-            return !stdout ? [] : stdout.split("\n");
+    function getCommitCounts() {
+        return git(["rev-list", "--left-right", "--count", "@{u}...@{0}"]).then(function (stdout) {
+            var reRevs = /(\d+)\s+(\d+)/;
+            var matches = reRevs.exec(stdout);
+            if (!matches) {
+                return false;
+            }
+            return {
+                behind: matches[1],
+                ahead: matches[2]
+            };
         });
     }
 
@@ -1067,7 +1075,7 @@ define(function (require, exports) {
     exports.rebaseRemote              = rebaseRemote;
     exports.resetRemote               = resetRemote;
     exports.getVersion                = getVersion;
-    exports.getCommitsAhead           = getCommitsAhead;
+    exports.getCommitCounts           = getCommitCounts;
     exports.getLastCommitMessage      = getLastCommitMessage;
     exports.mergeBranch               = mergeBranch;
     exports.getDiffOfAllIndexFiles    = getDiffOfAllIndexFiles;

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -887,7 +887,11 @@ define(function (require, exports) {
             var reRevs = /(\d+)\s+(\d+)/;
             var matches = reRevs.exec(stdout);
             if (!matches) {
-                throw new Error("Couldn't process getCommitCounts; rev-list could not be parsed.");
+                ErrorHandler.logError(new Error("Couldn't process getCommitCounts; rev-list could not be parsed."));
+                return {
+                    behind: -1,
+                    ahead: -1
+                };
             }
             return {
                 behind: matches[1],

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -887,11 +887,7 @@ define(function (require, exports) {
             var reRevs = /(\d+)\s+(\d+)/;
             var matches = reRevs.exec(stdout);
             if (!matches) {
-                ErrorHandler.logError(new Error("Couldn't process getCommitCounts; rev-list could not be parsed."));
-                return {
-                    behind: -1,
-                    ahead: -1
-                };
+                throw ErrorHandler.logError(new Error("Couldn't process getCommitCounts; rev-list could not be parsed."));
             }
             return {
                 behind: matches[1],

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -887,7 +887,7 @@ define(function (require, exports) {
             var reRevs = /(\d+)\s+(\d+)/;
             var matches = reRevs.exec(stdout);
             if (!matches) {
-                return false;
+                throw new Error("Couldn't process getCommitCounts; rev-list could not be parsed.");
             }
             return {
                 behind: matches[1],


### PR DESCRIPTION
Fixes #604 

Here is a summary of changes:

* Changed ```getCommitsAhead()``` to ```getCommitCounts()``` - this new function gets both ahead and behind in one command, returns an object
* Added ```refreshCommitCounts()``` which calls ```getCommitCounts()```, then updates the pull and push buttons
    * ~~This function calls a ```fetchRemote()``` on the current remote (some of this based off code in **Remotes.js**) - this is because a fetch is required to see how many commits we're behind the remote.~~ Removed this, too heavy on large repos. Manual for now.
* Added a Panel include to Remotes as I need it to refresh the panel when changing remotes

Also I noticed that when running ```grunt jshint``` it didn't cover everything that Travis does (jscs as well), so I read the **Gruntfile.js** and discovered that Travis must be using ```grunt test```. I linted with that and decided that **Contributing.md** may need to be updated. It's there in one of the commits anyway :).

I'm open to any further changes you require if need be.