### PR TITLE
Added fetch button

### DIFF
--- a/nls/root/strings.js
+++ b/nls/root/strings.js
@@ -203,6 +203,7 @@ define({
     TOOLTIP_CLONE:                      "Clone existing repository",
     TOOLTIP_CLOSE_NOT_MODIFIED:         "Close files not modified in Git [Shift-click to reopen modified files]",
     TOOLTIP_COMMIT:                     "Commit the selected files",
+    TOOLTIP_FETCH:                      "Fetch and sync all",
     TOOLTIP_FIND_CONFLICTS:             "Starts a search for Git merge/rebase conflicts in the project",
     TOOLTIP_GITPUSH:                    "Git-FTP Push",
     TOOLTIP_HIDE_FILE_HISTORY:          "Hide file history",

--- a/src/Events.js
+++ b/src/Events.js
@@ -35,6 +35,7 @@ define(function (require, exports) {
     exports.HANDLE_GIT_INIT = "handle.git.init";
     exports.HANDLE_GIT_CLONE = "handle.git.clone";
     exports.HANDLE_GIT_COMMIT = "handle.git.commit";
+    exports.HANDLE_FETCH = "handle.fetch";
     exports.HANDLE_PUSH = "handle.push";
     exports.HANDLE_PULL = "handle.pull";
     exports.HANDLE_REMOTE_PICK = "handle.remote.pick";
@@ -50,6 +51,8 @@ define(function (require, exports) {
     exports.GIT_REMOTE_AVAILABLE = "git.remote.available";
     exports.GIT_REMOTE_NOT_AVAILABLE = "git.remote.not.available";
     exports.REMOTES_REFRESH_PICKER = "remotes.refresh.picker";
+    exports.FETCH_STARTED = "remotes.fetch.started";
+    exports.FETCH_COMPLETE = "remotes.fetch.complete";
 
     // utils/Terminal.js
     exports.TERMINAL_OPEN = "terminal.open";

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1135,6 +1135,7 @@ define(function (require, exports) {
             .on("click", ".authors-file", handleAuthorsFile)
             .on("click", ".git-file-history", EventEmitter.emitFactory(Events.HISTORY_SHOW, "FILE"))
             .on("click", ".git-history-toggle", EventEmitter.emitFactory(Events.HISTORY_SHOW, "GLOBAL"))
+            .on("click", ".git-fetch", EventEmitter.emitFactory(Events.HANDLE_FETCH))
             .on("click", ".git-push", function () {
                 var typeOfRemote = $(this).attr("x-selected-remote-type");
                 if (typeOfRemote === "git") {
@@ -1268,13 +1269,11 @@ define(function (require, exports) {
     });
 
     EventEmitter.on(Events.GIT_REMOTE_AVAILABLE, function () {
-        $gitPanel.find(".git-pull").prop("disabled", false);
-        $gitPanel.find(".git-push").prop("disabled", false);
+        $gitPanel.find(".git-pull, .git-push, .git-fetch").prop("disabled", false);
     });
 
     EventEmitter.on(Events.GIT_REMOTE_NOT_AVAILABLE, function () {
-        $gitPanel.find(".git-pull").prop("disabled", true);
-        $gitPanel.find(".git-push").prop("disabled", true);
+        $gitPanel.find(".git-pull, .git-push, .git-fetch").prop("disabled", true);
     });
 
     EventEmitter.on(Events.GIT_ENABLED, function () {
@@ -1316,6 +1315,19 @@ define(function (require, exports) {
         $gitPanel.find(".git-rebase").toggle(rebaseEnabled);
         $gitPanel.find(".git-merge").toggle(mergeEnabled);
         $gitPanel.find("button.git-commit").toggle(!rebaseEnabled && !mergeEnabled);
+    });
+
+    EventEmitter.on(Events.FETCH_STARTED, function () {
+        $gitPanel.find(".git-fetch")
+            .addClass("btn-loading")
+            .prop("disabled", true);
+    });
+
+    EventEmitter.on(Events.FETCH_COMPLETE, function () {
+        $gitPanel.find(".git-fetch")
+            .removeClass("btn-loading")
+            .prop("disabled", false);
+        refreshCommitCounts();
     });
 
     EventEmitter.on(Events.HANDLE_GIT_COMMIT, function () {

--- a/src/Remotes.js
+++ b/src/Remotes.js
@@ -323,24 +323,19 @@ define(function (require) {
     function handleFetch(silent) {
         var q = Promise.resolve();
 
-        // Define the fetch action promise to use
-        var action = Git.fetchAllRemotes;
-
         // Tell the rest of the plugin that the fetch has started
         EventEmitter.emit(Events.FETCH_STARTED);
 
         if (!silent) {
             // If it's not a silent fetch show a progress window
-            q = q.then(function () {
-                return ProgressDialog.show(action());
-            })
+            q = q.then(ProgressDialog.show(Git.fetchAllRemotes()))
             .catch(function (err) {
                 ErrorHandler.showError(err);
             })
             .then(ProgressDialog.waitForClose);
         } else {
             // Else fetch in the background
-            q = action()
+            q = Git.fetchAllRemotes()
             .catch(function (err) {
                 ErrorHandler.logError(err);
             });

--- a/styles/brackets-git.less
+++ b/styles/brackets-git.less
@@ -213,9 +213,6 @@
     .git-remotes {
         border-radius: 4px 0 0 4px;
         padding-bottom: 5px;
-        &, &:focus {
-            border-right: 0;
-        }
         .caret {
             border-bottom-color: @bc-text;
             margin: 7px 5px auto 0px;

--- a/templates/git-panel.html
+++ b/templates/git-panel.html
@@ -81,11 +81,12 @@
         <!-- on right -->
         <div class="git-right-icons">
             <div class="btn-group git-available dropup">
+                <ul class="dropdown-menu git-remotes-dropdown"></ul>
                 <button type="button" class="git-remotes btn small dropdown-toggle" data-toggle="dropdown" title="{{S.TOOLTIP_PICK_REMOTE}}">
                     <span class="caret"></span>
                     <span class="git-selected-remote">&mdash;</span>
                 </button>
-                <ul class="dropdown-menu git-remotes-dropdown"></ul>
+                <button title="{{S.TOOLTIP_FETCH}}" class="btn small git-fetch"><i class="octicon octicon-cloud-download"></i></button>
                 <button title="{{S.TOOLTIP_PULL}}" class="btn small git-pull"><i class="octicon octicon-repo-pull"></i></button>
                 <button title="{{S.TOOLTIP_PUSH}}" class="btn small git-push"><i class="octicon octicon-repo-push"></i></button>
             </div>


### PR DESCRIPTION
Fixes #1255

* Added fetch button to **git-panel.html**
* Added tooltip to **strings.js**
* Disables fetch button when there are no remotes available
* Added ```handleFetch(bool)``` with a ```silent``` option to be used later with automatic fetches
* The fetch button uses .btn-loading when a fetch is in progress. When ```silent``` is used later this will be more useful to see when automatic fetches happen.

Minor things:
* Removed small gap between remotes drop down and next button (ul with pos: absolute is now before the button). Also added the right border back so that it looks pretty.
* Changed a Panel.refresh() from last PR to emit events instead.