### PR TITLE
Commit counter checks current upstream, remote pick only refreshes counter

### DIFF
--- a/src/Events.js
+++ b/src/Events.js
@@ -43,6 +43,7 @@ define(function (require, exports) {
     exports.HANDLE_REMOTE_CREATE = "handle.remote.create";
     exports.HANDLE_FTP_PUSH = "handle.ftp.push";
     exports.HISTORY_SHOW = "history.show";
+    exports.REFRESH_COUNTERS = "refresh.counters";
 
     // Git results
     exports.GIT_STATUS_RESULTS = "git.status.results";

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1337,6 +1337,10 @@ define(function (require, exports) {
         refreshCommitCounts();
     });
 
+    EventEmitter.on(Events.REFRESH_COUNTERS, function () {
+        refreshCommitCounts();
+    });
+
     EventEmitter.on(Events.HANDLE_GIT_COMMIT, function () {
         handleGitCommit(lastCommitMessage, false, COMMIT_MODE.DEFAULT);
     });

--- a/src/Remotes.js
+++ b/src/Remotes.js
@@ -362,7 +362,7 @@ define(function (require) {
             remoteName  = $remote.data("remote-name"),
             type        = $remote.data("type");
         selectRemote(remoteName, type);
-        EventEmitter.emit(Events.REFRESH_ALL);
+        EventEmitter.emit(Events.REFRESH_COUNTERS);
     });
     EventEmitter.on(Events.HANDLE_REMOTE_CREATE, function () {
         handleRemoteCreation();

--- a/src/git/GitCli.js
+++ b/src/git/GitCli.js
@@ -883,20 +883,25 @@ define(function (require, exports) {
     }
 
     function getCommitCounts() {
-        return git(["rev-list", "--left-right", "--count", "@{u}...@{0}"])
-        .catch(function (err) {
-            ErrorHandler.logError(err);
-            return null;
-        })
-        .then(function (stdout) {
-            var matches = /(\d+)\s+(\d+)/.exec(stdout);
-            return matches ? {
-                behind: parseInt(matches[1], 10),
-                ahead: parseInt(matches[2], 10)
-            } : {
-                behind: -1,
-                ahead: -1
-            }
+        var remotes = Preferences.get("defaultRemotes") || {};
+        var remote = remotes[Preferences.get("currentGitRoot")];
+        return getCurrentBranchName()
+        .then(function (branch) {
+            return git(["rev-list", "--left-right", "--count", remote + "/" + branch + "...@{0}"])
+            .catch(function (err) {
+                ErrorHandler.logError(err);
+                return null;
+            })
+            .then(function (stdout) {
+                var matches = /(\d+)\s+(\d+)/.exec(stdout);
+                return matches ? {
+                    behind: parseInt(matches[1], 10),
+                    ahead: parseInt(matches[2], 10)
+                } : {
+                    behind: -1,
+                    ahead: -1
+                };
+            });
         });
     }
 


### PR DESCRIPTION
Fixes #1257 and #1259

**Note**: While this works there is no checking to see whether branch or remote is undefined, so there are some errors on the console when working with remoteless repos. I need some advise on how to return `{ behind: -1, ahead: -1 }` if one of these are undefined.