### PR TITLE
changed position of branch button and dropdown

### DIFF
--- a/src/Branch.js
+++ b/src/Branch.js
@@ -461,7 +461,6 @@ define(function (require, exports) {
                         .attr("title", branchName.length > MAX_LEN ? branchName : null)
                         .off("click")
                         .on("click", toggleDropdown)
-                        .append($("<span class='dropdown-arrow' />"));
                     Panel.enable();
 
                 }).catch(function (err) {

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -460,7 +460,7 @@ define(function (require, exports) {
                         .text(branchName.length > MAX_LEN ? branchName.substring(0, MAX_LEN) + "\u2026" : branchName)
                         .attr("title", branchName.length > MAX_LEN ? branchName : null)
                         .off("click")
-                        .on("click", toggleDropdown)
+                        .on("click", toggleDropdown);
                     Panel.enable();
 
                 }).catch(function (err) {

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -341,7 +341,8 @@ define(function (require, exports) {
             $dropdown
                 .css({
                     left: toggleOffset.left,
-                    top: toggleOffset.top + $gitBranchName.outerHeight()
+                    top: toggleOffset.top - $gitBranchName.outerHeight() - (branches.length * 32) - 36,
+                    height: (branches.length * 32) + 36
                 })
                 .appendTo($("body"));
 
@@ -485,15 +486,15 @@ define(function (require, exports) {
     function init() {
         // Add branch name to project tree
         $gitBranchName = $("<span id='git-branch'></span>");
-        $("<div id='git-branch-dropdown-toggle' class='btn-alt-quiet'></div>")
-            .append("[ ")
+        $("#status-indicators div.spinner").before($("<div id='git-branch-dropdown-toggle' class='btn btn-dropdown btn-status-bar'></div>")
+            .append("<i class='octicon octicon-git-branch'></i> [ ")
             .append($gitBranchName)
             .append(" ]")
             .on("click", function () {
                 $gitBranchName.click();
                 return false;
-            })
-            .appendTo("#project-files-header");
+            }));
+
         refresh();
     }
 


### PR DESCRIPTION
solution for issue [1081](https://github.com/zaggino/brackets-git/issues/1081).

I think the positioning of the dropdown could be improved, but it's not the issue here.

When used together with another popular [extension](http://brackets.dnbard.com/extension/custom-work-for-brackets), the branch switcher is just occupying to much space there.

<img width="344" alt="screen shot 2016-02-26 at 19 11 00" src="https://cloud.githubusercontent.com/assets/2327306/13361329/466c9346-dcbe-11e5-879b-a9d8c5c388ff.png">

I'm not a fan of the "close files" button, but I couldn't find a better place to put it right now.

Please consider this change, as I would like to see it implemented soon.

<img width="1018" alt="screen shot 2016-02-26 at 19 09 39" src="https://cloud.githubusercontent.com/assets/2327306/13361334/549996e4-dcbe-11e5-883f-a0f0136b39c0.png">