### PR TITLE
moved the branch to a different line, to give it more room

### DIFF
--- a/src/Branch.js
+++ b/src/Branch.js
@@ -485,10 +485,9 @@ define(function (require, exports) {
     function init() {
         // Add branch name to project tree
         $gitBranchName = $("<span id='git-branch'></span>");
-        $("<div id='git-branch-dropdown-toggle' class='btn-alt-quiet'></div>")
-            .append("[ ")
+        $("<div id='git-branch-dropdown-toggle' class='btn-alt-quiet' style='display: block;'></div>")
+            .append("<i class='octicon octicon-git-branch'></i> ")
             .append($gitBranchName)
-            .append(" ]")
             .on("click", function () {
                 $gitBranchName.click();
                 return false;


### PR DESCRIPTION
the previous solution was a no go.

After working with lots of other methods, I thought about having the branch move to the main view's .not-editor, when no file was opened, but due to lots of deprecated stuff that the main team is adding, it will break very soon. No point on wasting so much time on this.

I just moved the control below the original project folder.
<img width="167" alt="screen shot 2016-03-03 at 16 25 17" src="https://cloud.githubusercontent.com/assets/2327306/13498973/8eb98e54-e15c-11e5-914b-d3ac826265b7.png">
No configuration is needed, it's just a fast fix for the overlapping project and branch controls.
