### PR TITLE
Require Mustache (changed in Brackets 1.7)

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -38,7 +38,6 @@
         "document": true,
         "brackets": true,
         "define": true,
-        "Mustache": true,
         "window": true
     }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,8 +17,7 @@ module.exports = function (grunt) {
                         "$": true,
                         "document": true,
                         "brackets": true,
-                        "define": true,
-                        "Mustache": true
+                        "define": true
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "zaggino.brackets-git",
     "title": "Brackets Git",
     "version": "0.16.5",
-    "engines": { "brackets": ">=1.2.0" },
+    "engines": { "brackets": ">=1.7.0" },
     "description": "Integration of Git into Brackets",
     "keywords": ["brackets-extension", "git", "version-control", "source-control"],
     "homepage": "https://github.com/zaggino/brackets-git",

--- a/src/Branch.js
+++ b/src/Branch.js
@@ -8,6 +8,7 @@ define(function (require, exports) {
         FileSyncManager         = brackets.getModule("project/FileSyncManager"),
         FileSystem              = brackets.getModule("filesystem/FileSystem"),
         Menus                   = brackets.getModule("command/Menus"),
+        Mustache                = brackets.getModule("thirdparty/mustache/mustache"),
         PopUpManager            = brackets.getModule("widgets/PopUpManager"),
         StringUtils             = brackets.getModule("utils/StringUtils"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),

--- a/src/ChangelogDialog.js
+++ b/src/ChangelogDialog.js
@@ -4,6 +4,7 @@ define(function (require, exports) {
     var Dialogs                    = brackets.getModule("widgets/Dialogs"),
         FileSystem                 = brackets.getModule("filesystem/FileSystem"),
         FileUtils                  = brackets.getModule("file/FileUtils"),
+        Mustache                   = brackets.getModule("thirdparty/mustache/mustache"),
         StringUtils                = brackets.getModule("utils/StringUtils"),
         Utils                      = require("src/Utils"),
         Preferences                = require("./Preferences"),

--- a/src/ErrorHandler.js
+++ b/src/ErrorHandler.js
@@ -3,6 +3,7 @@ define(function (require, exports) {
 
     var _                          = brackets.getModule("thirdparty/lodash"),
         Dialogs                    = brackets.getModule("widgets/Dialogs"),
+        Mustache                   = brackets.getModule("thirdparty/mustache/mustache"),
         NativeApp                  = brackets.getModule("utils/NativeApp"),
         ExpectedError              = require("./ExpectedError"),
         ExtensionInfo              = require("./ExtensionInfo"),

--- a/src/History.js
+++ b/src/History.js
@@ -3,7 +3,8 @@ define(function (require) {
     // Brackets modules
     var _ = brackets.getModule("thirdparty/lodash"),
         DocumentManager = brackets.getModule("document/DocumentManager"),
-        FileUtils = brackets.getModule("file/FileUtils");
+        FileUtils = brackets.getModule("file/FileUtils"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var moment = require("moment"),

--- a/src/HistoryViewer.js
+++ b/src/HistoryViewer.js
@@ -2,7 +2,8 @@ define(function (require, exports) {
     "use strict";
 
     var _               = brackets.getModule("thirdparty/lodash"),
-        FileUtils       = brackets.getModule("file/FileUtils");
+        FileUtils       = brackets.getModule("file/FileUtils"),
+        Mustache        = brackets.getModule("thirdparty/mustache/mustache");
 
     var marked        = require("marked"),
         ErrorHandler  = require("src/ErrorHandler"),

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -16,6 +16,7 @@ define(function (require, exports) {
         KeyBindingManager  = brackets.getModule("command/KeyBindingManager"),
         FileSystem         = brackets.getModule("filesystem/FileSystem"),
         Menus              = brackets.getModule("command/Menus"),
+        Mustache           = brackets.getModule("thirdparty/mustache/mustache"),
         FindInFiles        = brackets.getModule("search/FindInFiles"),
         WorkspaceManager   = brackets.getModule("view/WorkspaceManager"),
         ProjectManager     = brackets.getModule("project/ProjectManager"),

--- a/src/Remotes.js
+++ b/src/Remotes.js
@@ -5,6 +5,7 @@ define(function (require) {
     var _               = brackets.getModule("thirdparty/lodash"),
         DefaultDialogs  = brackets.getModule("widgets/DefaultDialogs"),
         Dialogs         = brackets.getModule("widgets/Dialogs"),
+        Mustache        = brackets.getModule("thirdparty/mustache/mustache"),
         StringUtils     = brackets.getModule("utils/StringUtils");
 
     // Local modules

--- a/src/SettingsDialog.js
+++ b/src/SettingsDialog.js
@@ -5,6 +5,7 @@ define(function (require, exports) {
     var _                       = brackets.getModule("thirdparty/lodash"),
         CommandManager          = brackets.getModule("command/CommandManager"),
         Dialogs                 = brackets.getModule("widgets/Dialogs"),
+        Mustache                = brackets.getModule("thirdparty/mustache/mustache"),
         Preferences             = require("./Preferences"),
         ChangelogDialog         = require("../src/ChangelogDialog"),
         Strings                 = require("../strings"),

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
         FileSystem      = brackets.getModule("filesystem/FileSystem"),
         FileUtils       = brackets.getModule("file/FileUtils"),
         LanguageManager = brackets.getModule("language/LanguageManager"),
+        Mustache        = brackets.getModule("thirdparty/mustache/mustache"),
         ProjectManager  = brackets.getModule("project/ProjectManager");
 
     // Local modules

--- a/src/dialogs/Clone.js
+++ b/src/dialogs/Clone.js
@@ -2,7 +2,8 @@ define(function (require, exports) {
     "use strict";
 
     // Brackets modules
-    var Dialogs = brackets.getModule("widgets/Dialogs");
+    var Dialogs = brackets.getModule("widgets/Dialogs"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var Promise         = require("bluebird"),

--- a/src/dialogs/Progress.js
+++ b/src/dialogs/Progress.js
@@ -3,7 +3,8 @@ define(function (require, exports) {
 
     // Brackets modules
     var _ = brackets.getModule("thirdparty/lodash"),
-        Dialogs = brackets.getModule("widgets/Dialogs");
+        Dialogs = brackets.getModule("widgets/Dialogs"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var Promise = require("bluebird"),

--- a/src/dialogs/Pull.js
+++ b/src/dialogs/Pull.js
@@ -2,7 +2,8 @@ define(function (require, exports) {
     "use strict";
 
     // Brackets modules
-    var Dialogs = brackets.getModule("widgets/Dialogs");
+    var Dialogs = brackets.getModule("widgets/Dialogs"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var Preferences     = require("src/Preferences"),

--- a/src/dialogs/Push.js
+++ b/src/dialogs/Push.js
@@ -2,7 +2,8 @@ define(function (require, exports) {
     "use strict";
 
     // Brackets modules
-    var Dialogs = brackets.getModule("widgets/Dialogs");
+    var Dialogs = brackets.getModule("widgets/Dialogs"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var Promise         = require("bluebird"),

--- a/src/dialogs/RemoteCommon.js
+++ b/src/dialogs/RemoteCommon.js
@@ -2,7 +2,8 @@ define(function (require, exports) {
     "use strict";
 
     // Brackets modules
-    var _ = brackets.getModule("thirdparty/lodash");
+    var _ = brackets.getModule("thirdparty/lodash"),
+        Mustache = brackets.getModule("thirdparty/mustache/mustache");
 
     // Local modules
     var ErrorHandler    = require("src/ErrorHandler"),

--- a/src/ftp/Ftp.js
+++ b/src/ftp/Ftp.js
@@ -4,6 +4,7 @@ define(function (require) {
     var _               = brackets.getModule("thirdparty/lodash"),
         DefaultDialogs  = brackets.getModule("widgets/DefaultDialogs"),
         Dialogs         = brackets.getModule("widgets/Dialogs"),
+        Mustache        = brackets.getModule("thirdparty/mustache/mustache"),
         StringUtils     = brackets.getModule("utils/StringUtils");
 
     // Local modules


### PR DESCRIPTION
Changed in Brackets 1.7 (not yet released), Mustache should now be required (it will still work as it is for a deprecation timespan, though).
So, feel free to wait until you merge this, as it is not urgent.