### PR TITLE
Mark initial commit to fix error showing commit details

### DIFF
--- a/src/History.js
+++ b/src/History.js
@@ -125,6 +125,10 @@ define(function (require) {
                 $historyList = $tableContainer.find("#git-history-list")
                     .data("file", file ? file.absolute : null)
                     .data("file-relative", file ? file.relative : null);
+
+                $historyList
+                    .find("tr.history-commit:last-child")
+                    .attr("x-initial-commit", "true");
             });
         }).catch(function (err) {
             ErrorHandler.showError(err, "Failed to get history");


### PR DESCRIPTION
Basically this fixes an error being displayed when you click on the initial commit to see details.
See issue description: https://github.com/zaggino/brackets-git/issues/1311

Initial commit is handled in a different way when trying to get the diff, however to identify an initial commit a new attribute is added to it. This is only done when we have a scroll, so the fix adds this identification also when it is rendered for the first time